### PR TITLE
Change release number to final 3.19.3.0

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,7 +26,7 @@ author = u'KC0EUW'
 # The short X.Y version
 version = u'3.19.3.0'
 # The full version, including alpha/beta/rc tags
-release = u'3.19.3.0 pre-release'
+release = u'3.19.3.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@
 AREDN Documentation
 ===================
 
-:Version: 3.19.3.0 pre-release
+:Version: 3.19.3.0
 
 This documentation set consists of several sections which are shown in the navigation list.
 


### PR DESCRIPTION
Change the release number to 3.19.3.0 before adding tag to documentation 
repository.