### PR TITLE
Correct dnsmasq IP range for linux mikrotik install

### DIFF
--- a/arednGettingStarted/installing_firmware.rst
+++ b/arednGettingStarted/installing_firmware.rst
@@ -142,7 +142,7 @@ Mikrotik First Install Process
 3. Become ``root`` and open a terminal window to execute the following dnsmasq command:
 
   >>>
-  # dnsmasq -i eth0 -u joe --dhcp-range=192.168.0.100,192.168.0.200  \
+  # dnsmasq -i eth0 -u joe --dhcp-range=192.168.1.100,192.168.1.200  \
     --dhcp-boot=rb.elf --enable-tftp --tftp-root=/tftp/  \
     -d -p0 -K --log-dhcp --bootp-dynamic
 


### PR DESCRIPTION
Correct typo in the dnsmasq IP range for a linux install of Mikrotik hAP 
ac lite.