### PR TITLE
Change Advanced Config title

### DIFF
--- a/arednGettingStarted/advanced_config.rst
+++ b/arednGettingStarted/advanced_config.rst
@@ -1,8 +1,8 @@
-======================
-Advanced Configuration
-======================
+=======================
+Configuration Deep Dive
+=======================
 
-During your node's *Basic Setup* you used the configuration display by clicking the **Setup** button and typing your username and password. The configuration area has several additional features which will be described in more detail below. Clicking **Node Status** exits configuration mode without saving any changes, returning you to the *Node Status* display.
+During your node's *Basic Setup* you used the configuration display by clicking the **Setup** button and typing your username and password. The configuration area has many additional features which will be described in more detail below. Clicking **Node Status** exits configuration mode without saving any changes, returning you to the *Node Status* display.
 
 .. image:: _images/admin-header.png
    :alt: Admin Navigation Controls

--- a/arednGettingStarted/basic_setup.rst
+++ b/arednGettingStarted/basic_setup.rst
@@ -48,7 +48,7 @@ Channel and Channel Width
 
 **Active Settings**
 
-  See the *Advanced Configuration* section for more information about these and other settings in the **Mesh RF** column.
+  See the *Configuration Deep Dive* section for more information about these and other settings in the **Mesh RF** column.
 
   * Use the dropdown list to select the maximum output power for this device. Remember that amateur operators are required to use the minimum power necessary to make contact with other stations.
 

--- a/arednGettingStarted/installing_firmware.rst
+++ b/arednGettingStarted/installing_firmware.rst
@@ -4,7 +4,7 @@ Installing AREDN |trade| Firmware
 
 There are two cases for installing AREDN |trade| firmware:
 
-1. If you already have an existing version of AREDN |trade| running on your device, then you can use your computer's web interface to navigate to **Setup > Administration > Firmware Update** to install your new firmware. This process will be explained in more detail in the **Advanced Configuration** section of this guide. Also, see *Firmware Upgrade Tips* in the **How-to Guides** section for additional information.
+1. If you already have an existing version of AREDN |trade| running on your device, then you can use your computer's web interface to navigate to **Setup > Administration > Firmware Update** to install your new firmware. This process will be explained in more detail in the **Configuration Deep Dive** section of this guide. Also, see *Firmware Upgrade Tips* in the **How-to Guides** section for additional information.
 
 2. If you are installing AREDN |trade| firmware on a device for the first time, each hardware platform may require a unique procedure.
 

--- a/arednGettingStarted/node_status.rst
+++ b/arednGettingStarted/node_status.rst
@@ -54,7 +54,7 @@ The AREDN |trade| development team has the ability to post messages which Intern
    :alt: AAM Display
    :align: center
 
-Mesh nodes without Internet access also have the ability to display *Local Alerts*. The process for setting up a local message repository is described in the **Advanced Configuration** section. If a node has Internet access as well as local messages, then both types of messages will be displayed in the AREDN |trade| alerts banner as shown in the example above.
+Mesh nodes without Internet access also have the ability to display *Local Alerts*. The process for setting up a local message repository is described in the **Configuration Deep Dive** section. If a node has Internet access as well as local messages, then both types of messages will be displayed in the AREDN |trade| alerts banner as shown in the example above.
 
 Signal Charts
 -------------


### PR DESCRIPTION
Change the Advanced Configuration section title to Configuration Deep 
Dive in order to avoid confusion with the existing Advanced 
Configuration menu item. Also change all project references to the old 
section title.