### PR TITLE
Set trademark macro once for all

### DIFF
--- a/appendix/freq_charts.rst
+++ b/appendix/freq_charts.rst
@@ -7,7 +7,3 @@ The frequencies and channels that are available for AREDN |trade| networking are
 .. image:: ../_images/AREDN-bands.png
    :alt: AREDN bands and channels
    :align: center
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/appendix/more_info.rst
+++ b/appendix/more_info.rst
@@ -26,7 +26,3 @@ The workflow for contributing documentation is described in the file titled `How
 Your local editing branch name can be anything that makes sense to you as you add topics to the documentation. AREDN |trade| documentation is written using the `reStructuredText <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html>`_ markup language and your text is saved in "rst" files. Before committing your changes, be sure to test your rst files locally using `Sphinx <https://www.sphinx-doc.org/en/master/usage/quickstart.html>`_ to ensure they will render correctly.
 
 After you create a Pull Request on GitHub, the AREDN |trade| team will review your changes. Once your documentation contributions are committed to the AREDN |trade| GitHub repository, a webhook automatically updates and builds the latest docs for viewing and exporting on ReadTheDocs.org
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/advanced_config.rst
+++ b/arednGettingStarted/advanced_config.rst
@@ -351,6 +351,3 @@ With the node powered on and fully booted:
 * **Hold for 15 seconds to return the node to “just-flashed” condition**
 
 On some equipment models it may be possible to accomplish these reset procedures by pressing the *Reset* button on the PoE unit.
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/aredn_overview.rst
+++ b/arednGettingStarted/aredn_overview.rst
@@ -19,7 +19,3 @@ The amateur radio community is able to meet these high-bandwidth digital communi
 An AREDN |trade| network is able to serve as the transport mechanism for the preferred applications people rely upon to communicate with each other in the normal course of their business and social interactions, including email, chat, phone service, document sharing, video conferencing, and many other useful programs. Depending on the characteristics of the AREDN |trade| implementation, this digital data network can operate at near-Internet speeds with many miles between network nodes.
 
 The primary goal of the AREDN |trade| project is to empower licensed amateur radio operators to quickly and easily deploy high-speed data networks when and where they might be needed, as a service both to the hobby and the community. This is especially important in cases when traditional "utility" services (electricity, phone lines, or Internet services) become unavailable. In those cases an off-grid amateur radio emergency data network may be a lifeline for communities impacted by a local disaster.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/basic_setup.rst
+++ b/arednGettingStarted/basic_setup.rst
@@ -78,7 +78,3 @@ In this section you can enter your node's latitude and longitude, as well as the
 * Click the **Apply Location Settings** button after entering new location information on this page. The new settings become active without clicking the *Save Changes* button.
 
 You may also change the timezone for your node's system time, as well as selecting a `Network Time Protocol (NTP) <https://en.wikipedia.org/wiki/Network_Time_Protocol>`_ source if your node is connected to a network which has a network time server.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/downloading_firmware.rst
+++ b/arednGettingStarted/downloading_firmware.rst
@@ -32,7 +32,3 @@ Nightly Build Releases
 To download the latest build, navigate to the `Software > Nightly Builds <https://www.arednmesh.org/content/nightly-builds>`_ link on the AREDN |trade| website. You will find the most recent *README* file, a list of the latest changes included in the build, and a link to download the firmware. As explained above, select the correct target architecture for the device you will be flashing. To return your device to the current stable release, download the correct *Stable Release* firmware and reflash your device.
 
 *Nightly Build* filenames are prefixed with *aredn-XXXX-yyyyyyy*, where *XXXX* identifies the build number and *yyyyyyy* is a unique software commit identifier. Be aware that as new nightly builds become available, the older builds automatically become obsolete. If you want to install add-on packages for nodes running a nightly build, understand that specific packages may not be available for an *older* build if a *newer* build has already been released. To install packages on nightly build firmware, upgrade to the latest nightly build and then immediately install the packages you desire.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/installing_firmware.rst
+++ b/arednGettingStarted/installing_firmware.rst
@@ -223,6 +223,3 @@ Post-Install Steps
 Once your device is running AREDN |trade| firmware, you can display its web interface by connecting your computer to the LAN port on the :abbr:`PoE (Power over Ethernet)` and navigating to either ``http://192.168.1.1`` or ``http://localnode.local.mesh``. Some computers may have DNS search paths configured that require you to use the `fully qualified domain name (FQDN) <https://en.wikipedia.org/wiki/Fully_qualified_domain_name>`_ to resolve *localnode* to the mesh node's IP address. Each node will serve its web interface on both port 80 and 8080.
 
 By default AREDN |trade| devices run the :abbr:`DHCP (Dynamic Host Control Protocol)` service on their LAN interface, so your computer will receive an IP address from the node as soon as it is connected with an Ethernet cable. Ensure that your computer is set to obtain its IP address via :abbr:`DHCP (Dynamic Host Control Protocol)`. You may also need to clear your web browser's cache in order to remove cached pages remaining from your node's previous firmware version.
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/mesh_status.rst
+++ b/arednGettingStarted/mesh_status.rst
@@ -56,7 +56,3 @@ Remote Nodes
 
 Previous Nodes
   This section lists any nodes which were recently connected to your node but are not currently connected. It shows the node name or IP address, as well as how long it has been since a node was actively connected to your node.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/node_status.rst
+++ b/arednGettingStarted/node_status.rst
@@ -91,6 +91,3 @@ If you click and drag your mouse across a region of the chart, the display will 
    :align: left
 
 On the left of the Realtime Graph there is an **SNR Sound** control. Clicking the *On* button will cause your computer to emit a tone that corresponds to the relative SNR level, with higher pitch tones indicating better SNR. This feature was added in order to provide an audio queue to operators in the process of aligning directional antennas. When your antenna reaches a position at which the highest pitch tone is heard you can lock it down without having to look at the signal graph display, knowing that you are receiving the best signal available. You can also adjust the tone pitch and volume with the sliders on the sound control.
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednGettingStarted/selecting_devices.rst
+++ b/arednGettingStarted/selecting_devices.rst
@@ -18,7 +18,3 @@ One of the best sources of detailed hardware information is a manufacturer's dat
 If you are just getting started with AREDN |trade| you can easily begin with one of the low-cost devices that comes with an integrated antenna and a :abbr:`PoE (Power over Ethernet)` unit. If you are expanding your AREDN |trade| network with more sophisticated equipment, you may choose a standalone radio attached to a high-gain antenna.
 
 .. note:: See the **Network Design Guide** for more information about constructing robust mesh networks.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/devtools.rst
+++ b/arednHow-toGuides/devtools.rst
@@ -153,7 +153,3 @@ A *link_info* section will be included in the JSON data stream containing an ent
     }
   },
   ...
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/firmware_upgrade.rst
+++ b/arednHow-toGuides/firmware_upgrade.rst
@@ -39,7 +39,3 @@ Tips for legacy nodes with low memory (32mb)
     To transfer the image from a Windows computer you can use a *Secure Copy* program such as `WinSCP <https://winscp.net>`_. Then use a terminal program such as `PuTTY <https://www.chiark.greenend.org.uk/~sgtatham/putty/>`_ to connect to the node via ssh or telnet in order to run the sysupgrade command shown as the last line above.
 
   * As a last resort, use the TFTP procedure to load the *factory.bin* firmware image to the node. This procedure is described in the *First Install* sections of **Installing AREDN Firmware**.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/home-router-connection.rst
+++ b/arednHow-toGuides/home-router-connection.rst
@@ -11,7 +11,3 @@ There are several AREDN |trade| nodes that have more than one Ethernet port, inc
 When you connect the node's WAN port to one of the LAN ports on your home router, the node's WAN should receive an IP address on your home network from the router's `DHCP <https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol>`_ server. Alternatively you can reserve an IP address in your home network range and assign the static IP to the node's WAN through the **Basic Settings** page on your node. There are many sources of information about basic `home networking <https://en.wikipedia.org/wiki/Home_network>`_ which will not be duplicated here, but feel free to familiarize yourself with IP networking through reading and research.
 
 Once you have connected your node to your home router, Internet access will be available to the node itself as well as to any of the devices connected to the node's LAN network. It is not recommended to allow Internet access through your node from other Mesh RF connected nodes, therefore be sure to leave *"Allow others to use my WAN"* unchecked. If you do not want any of your node's LAN connected devices to access the Internet either, you can check *"Prevent LAN devices from accessing WAN"*.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/iperf.rst
+++ b/arednHow-toGuides/iperf.rst
@@ -23,7 +23,3 @@ After iperf and IperfSpeed are installed on your nodes, you can select the *Iper
 Once the test has completed you will see the collected data summarized by time interval, and at the bottom of the display is the overall average of the results from the perspective of the sender (client) and the receiver (server). IperfSpeed also tracks previous tests that have been run, and it allows you to rerun any of the previous tests by clicking the *Re-Test* button.
 
 One of the many uses for IperfSpeed is to validate and optimize your node's *Distance* setting on the **Basic Setup** page. Try different *Distance* settings and note the network bandwidth using iperf, with the goal of choosing the *Distance* setting which yields the best network performance.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/local-package-repo.rst
+++ b/arednHow-toGuides/local-package-repo.rst
@@ -73,7 +73,3 @@ The following example shows the type of information returned when you click the 
   ...
 
 Click the **Select Package** dropdown list to see the packages that are available for download to your node. Select a package and click the **Download** button. Status information will appear showing the actions that were taken to install the package from the local package host. A message may appear that a reboot is required to refresh and restart all services, but this is a normal status message and does not indicate an error condition.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/puttygen_ssh_keys.rst
+++ b/arednHow-toGuides/puttygen_ssh_keys.rst
@@ -114,7 +114,3 @@ SAVE the session definition again.
 .. image:: _images/20-puttygen.png
    :alt: Logged into node
    :align: center
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/radio_mobile_settings.rst
+++ b/arednHow-toGuides/radio_mobile_settings.rst
@@ -47,8 +47,3 @@ HT20/LGI     MCS14           0.0        0.0         0.0      0              0(  
 HT20/LGI     MCS15           0.0        0.0         0.0      0              0(  0)         0        3495
 
 The "T" in the 10th character position indicates the current MCS rate, and a "t" indicates the current fallback rate.  In this case the link is running MCS11 at 30.3 Mbps.
-
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednHow-toGuides/siso-mimo.rst
+++ b/arednHow-toGuides/siso-mimo.rst
@@ -73,6 +73,3 @@ Troubleshooting Tips
 * If you have a marginal SISO-to-SISO link and you must replace one of the radios, either install another SISO radio or replace both ends with MIMO devices. A marginal but usable link between SISO devices may become unusable if one is replaced with a MIMO device.
 
 Additional information on the operation of SISO and MIMO radios can be found in references such as this: `MIMO for Dummies <https://www.halper.in//pubs/mimo_for_dummies.pdf>`_.
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednNetworkDesign/channel_planning.rst
+++ b/arednNetworkDesign/channel_planning.rst
@@ -125,7 +125,3 @@ Based on the purpose for your network, try to create reliable paths to the locat
 * If you are installing long distance point-to-point links to connect mesh islands, be sure to use a separate band or channel for the backbone link. This type of link has a single purpose: to carry as much data as quickly as possible from one end to the other. Eliminate any type of channel contention so that these links can achieve high throughput.
 
 * Remember that a multi-hop path through the network must have good signal quality on each leg of the journey. You cannot expect adequate performance through a series of poor quality links. For example, if you traverse three links having :abbr:`LQ (Link Quality)` metrics of 65%, 45%, and 58%, your aggregate :abbr:`LQ (Link Quality)` will be 17% which is unusable. Ideally the aggregate :abbr:`LQ (Link Quality)` should be at least 80% to have a link that supports the applications and services you require.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednNetworkDesign/frequency_bands.rst
+++ b/arednNetworkDesign/frequency_bands.rst
@@ -78,7 +78,3 @@ Different frequency ranges are available to connect the mesh nodes that are requ
 ----------
 
 .. [footnote] Late in 2020 the `FCC ruled <https://docs.fcc.gov/public/attachments/FCC-20-138A1.pdf>`_ to sunset secondary Amateur allocations in the 9 cm *(3.3-3.5 GHz)* band. Although existing Amateur operations *"may continue while the Commission finalizes plans to reallocate spectrum,"* investing in or implementing new AREDN |trade| devices in this band is not recommended.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednNetworkDesign/network_modeling.rst
+++ b/arednNetworkDesign/network_modeling.rst
@@ -92,9 +92,3 @@ An example *Radio Mobile* coverage plot is shown below. After entering the site,
 .. image:: _images/radioMobile-coverage.png
    :alt: Radio Mobile Coverage Plot
    :align: center
-
-
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednNetworkDesign/network_topology.rst
+++ b/arednNetworkDesign/network_topology.rst
@@ -29,7 +29,3 @@ Endpoint Links
   Endpoint links are used to connect destination nodes to the mesh network. Sometimes these links are call "last mile", "tactical", or "terminal" nodes. Usually these nodes serve either as the originator or the final destination for network traffic. Depending on local conditions, endpoint links typically operate over distances of 3 miles or less.
 
 Different types of radio links may be needed to connect all of the mesh nodes that are required in order to fulfill the purposes for your network. The ultimate goal is to have a reliable data network that accomplishes its purpose for providing services to the intended destinations and users.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednNetworkDesign/networking_overview.rst
+++ b/arednNetworkDesign/networking_overview.rst
@@ -25,8 +25,3 @@ Applications and Throughput
   How many simultaneous users will be generating network traffic at different times? As the number of users increases, the amount of data traversing the network will also increase. In addition, with an increasing number of nodes on the network there will be a corresponding increase in the amount of `OLSR (Optimized Link State Routing protocol) <https://en.wikipedia.org/wiki/Optimized_Link_State_Routing_Protocol>`_ traffic that is necessary to maintain the mesh network. An AREDN |trade| network should be designed to handle the expected workload.
 
 With these issues in mind, it is always best to keep your network as simple as possible and to include only those services which are required. Be sure to design your network so that it accomplishes its mission and suits its intended purpose.
-
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/chat_programs.rst
+++ b/arednServicesGuide/chat_programs.rst
@@ -93,7 +93,3 @@ Let's Chat   client-server  small         new   lin/mac/rpi/win  medium
 Mattermost   client-server  medium        new   linux            expert
 Matrix       distributed    medium        new   linux/mac        expert
 ===========  =============  ============  ====  ===============  ======
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/dispatch_programs.rst
+++ b/arednServicesGuide/dispatch_programs.rst
@@ -63,7 +63,3 @@ EmComMap      open source     small        linux            medium
 ISES Tickets  open source     small        win/lin/mac/rpi  medium
 OpenCAD       open source     small        win/lin/mac/rpi  medium
 ============  ==============  ===========  ===============  ======
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/email_programs.rst
+++ b/arednServicesGuide/email_programs.rst
@@ -65,6 +65,3 @@ Citadel     groupware, webmail  small         lin/mac/rpi        easy
 Open Email  client-server       small         lin/mac/rpi        expert
 WinLink     email, attachments  small         win (proprietary)  medium
 ==========  ==================  ============  =================  ======
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/file_sharing.rst
+++ b/arednServicesGuide/file_sharing.rst
@@ -44,7 +44,3 @@ One example package that facilitates collaborative document creation is `Etherpa
 .. image:: _images/etherpad.png
    :alt: Etherpad Web Interface
    :align: center
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/other_programs.rst
+++ b/arednServicesGuide/other_programs.rst
@@ -58,7 +58,3 @@ There may be situations when it would also be helpful to track the locations of 
 ----------
 
 Depending on the requirements of your specific situation, almost any program that can operate across a peer-to-peer TCP/IP network could be deployed as a service on your mesh network. Check the `AREDN Forums <https://www.arednmesh.org/forum>`_ for additional information, ideas, and how-to posts about possible services for mesh networking.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/services_overview.rst
+++ b/arednServicesGuide/services_overview.rst
@@ -41,7 +41,3 @@ As a general rule for mesh networks, simpler is better. The more complicated and
 There are also programs which have been designed to take advantage of multiple paths between nodes and multiple peer servers coexisting on a mesh network. There are fewer of these mesh-friendly programs, but they will be identified as they appear in the following sections.
 
 The remaining parts of this section focus on examples of services that could be offered on your AREDN |trade| network. Programs are grouped by type, and where possible the network impact of each program will be described in order for you to understand the resources that may be required to use the program as a service on the mesh.
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/video_streaming.rst
+++ b/arednServicesGuide/video_streaming.rst
@@ -104,6 +104,3 @@ Shinobi     free for *NC* use  medium         lin/mac        medium
 ==========  =================  =============  =============  ======
 
 *NC ~ non-commercial*
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/arednServicesGuide/voip_programs.rst
+++ b/arednServicesGuide/voip_programs.rst
@@ -90,7 +90,3 @@ Mumble      voice + chat        medium        win/lin/mac         medium
 FreeSWITCH  PBX + video         medium-large  win/lin/mac/rpi     expert
 TeamTalk    video conferencing  large         win/lin/mac/rpi     easy
 ==========  ==================  ============  ==================  ======
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:

--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,12 @@ extensions = [
     'sphinx.ext.autodoc',
 ]
 
+# Include the trademark symbol in the prolog
+rst_prolog = """
+.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
+   :ltrim:
+"""
+
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['_templates']
 

--- a/index.rst
+++ b/index.rst
@@ -82,7 +82,3 @@ If you would like to see the documentation for a specific AREDN |trade| release,
 
    appendix/freq_charts
    appendix/more_info
-
-
-.. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
-   :ltrim:


### PR DESCRIPTION
Set the trademark macro once as a prolog to all RST files. Reduces the 
possibility of error by removing the requirement for the trademark macro 
within every RST.