### PR TITLE
Update GitHub auth method

### DIFF
--- a/How to Use GitHub for AREDN.md
+++ b/How to Use GitHub for AREDN.md
@@ -7,8 +7,8 @@
 To contribute to the AREDN project you first must create your own GitHub account. This is free and easy to do by following these steps:
 
 1. Open your web browser and navigate to the GitHub URL `https://github.com`.
-2. Click the `Sign Up` button and enter a username, email, and password. We suggest using your callsign as the username which will be indicated below as "myCall". You can, however, create any username you desire. Substitute your actual GitHub username for "myCall" in the examples below.
-3. On the GitHub website, click the `Sign In` button and enter your username or email, followed by your GitHub password.
+2. Click the `Sign Up` button and enter the required information. We suggest using your callsign as the username which will be indicated below as "myCall". You can, however, create any username you desire. Substitute your actual GitHub username for "myCall" in the examples below.
+3. On the GitHub website, click the `Sign In` button and authenticate to GitHub with the credentials you created.
 4. You can enter "aredn" into the search bar to find all repositories related to AREDN, or if you want to navigate directly to the AREDN documentation repository you can type this URL into your web browser: `https://github.com/aredn/documentation`.
 
 ### Understanding GitHub Workflow

--- a/appendix/more_info.rst
+++ b/appendix/more_info.rst
@@ -14,8 +14,8 @@ Contributing AREDN |trade| Documentation
 If you are interested in contributing to the rapidly growing set of AREDN |trade| documentation you can easily do so on GitHub. To contribute to the AREDN |trade| project you first must create your own GitHub account. This is free and easy to do by following these steps:
 
 1. Open your web browser and navigate to the `GitHub URL <https://github.com>`_.
-2. Click the ``Sign Up`` button and enter a username, email, and password. We suggest using your callsign as the username.
-3. On the GitHub website, click the ``Sign In`` button and enter your username or email followed by your GitHub password.
+2. Click the ``Sign Up`` button and enter the required information. We suggest using your callsign as the username.
+3. On the GitHub website, click the ``Sign In`` button and authenticate to GitHub with the credentials you created.
 4. Navigate on GitHub to the AREDN |trade| documentation repository: https://github.com/aredn/documentation.
 5. Click the ``Fork`` button at the upper right corner of the page. After this process completes, you will have your own copy of the AREDN |trade| documentation files on your GitHub account.
 6. Go to your local computer and clone your fork of the AREDN |trade| documentation: ``git clone https://github.com/YOUR-GITHUB-ID/documentation``


### PR DESCRIPTION
Update the docs to remove mentions of _password_ and generalize the wording to point to the latest GitHub authentication schemes (tokens, etc) as they evolve.