### PR TITLE
Add version macro in RST files

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,9 +24,9 @@ copyright = u'2021, Amateur Radio Emergency Data Network, Inc. Licensed under th
 author = u'Amateur Radio Emergency Data Network, Inc.'
 
 # The short X.Y version
-version = u'3.20.3.1'
+version = u'3.21.2.0'
 # The full version, including alpha/beta/rc tags
-release = u'3.20.3.1'
+release = u'3.21.2.0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -46,6 +46,7 @@ extensions = [
 rst_prolog = """
 .. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
    :ltrim:
+
 """
 
 # Add any paths that contain templates here, relative to this directory.

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@
 AREDN |trade| Documentation
 ===========================
 
-:Version: 3.20.3.1
+:Release: |release|
 
 This documentation set consists of several sections which are shown in the navigation list.
 


### PR DESCRIPTION
Add version macro in the RST files, which avoids hard coding version and release numbers in the RST files. Version/release only need to be updated in the Sphinx conf.py file now.