### PR TITLE
Adv Config Note Callouts

### DIFF
--- a/arednGettingStarted/advanced_config.rst
+++ b/arednGettingStarted/advanced_config.rst
@@ -288,6 +288,8 @@ Package Management
 Authorized SSH Keys
   Uploading ssh keys allows computers to connect to a node via ssh without having to know the password. The ssh keys are generated on your computer using built-in utilities or the `PuTTY <https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html>`_ program's *Key Generator*. Once you have the key files on your computer, you can upload its *public* key to your AREDN |trade| node. If you want to remove an installed key, select it and click the *Remove* button.
 
+  .. note:: If you plan to use ssh keys you may want to review **Use PuTTYGen to Make SSH Keys** in the **How-To Guide** section which describes this process in detail.
+
 Support Data
   There may be times when you want to view more detailed information about the configuration and operation of your node, or even forward this information to the AREDN |trade| forum in order to get help with a problem. Click *Download Support Data* to save a compressed archive file to your local computer.
 
@@ -308,7 +310,9 @@ Map Tile and Script Paths
 ----------
 
 Firmware and Package Download Paths
-  These fields contain the URLs used by the node for downloading firmware and package files during upgrades.
+  These fields contain the URLs used by the node for downloading firmware and package files during upgrades. By default they point to the AREDN |trade| downloads server available across the Internet. You can change these paths to point to a local mesh package server in order to upgrade nodes that do not have Internet access.
+
+  .. note:: If you plan to create a local software repository for your mesh network, review **Creating a Local Package Server** in the **How-To Guide** section.
 
   .. image:: _images/advConfig-downloads.png
     :alt: Advanced Configuration - downloads

--- a/conf.py
+++ b/conf.py
@@ -42,11 +42,16 @@ extensions = [
     'sphinx.ext.autodoc',
 ]
 
+rst_epilog = """
+`Link: AREDN Webpage <https://arednmesh.org>`_
+"""
+
 # Include the trademark symbol in the prolog
 rst_prolog = """
 .. |trade|  unicode:: U+00AE .. Registered Trademark SIGN
    :ltrim:
 
+`Link: AREDN Webpage <https://arednmesh.org>`_   
 """
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Add note callouts to several Advanced Configuration items, referring readers to more detailed discussions in the How-To section.