### PR TITLE
clarify differences in Quality metrics

### DIFF
--- a/arednGettingStarted/mesh_status.rst
+++ b/arednGettingStarted/mesh_status.rst
@@ -36,7 +36,7 @@ Local Hosts
 Current Neighbors
   This shows a list of *Neighbor Nodes* that are directly connected with your node (1 hop). These nodes may be connected via :abbr:`RF (Radio Frequency)`, :abbr:`DtD (Device to Device)` link using an Ethernet cable, or a tunnel over an Internet connection. There are several link quality statistics displayed for each connected node.
 
-  - ``LQ`` or Link Quality is your node's view of the percent of `OLSR (Optimized Link State Routing protocol) <https://en.wikipedia.org/wiki/Optimized_Link_State_Routing_Protocol>`_ packets received from the neighbor node. These packets exchange mesh routing and advertised services information, and they include a sequence number that is used to identify missing packets which is a measure of the quality of the link.
+  - ``LQ`` or Link Quality is your node's view of the percent of `OLSR (Optimized Link State Routing protocol) <https://en.wikipedia.org/wiki/Optimized_Link_State_Routing_Protocol>`_ packets received from the neighbor node. These packets exchange mesh routing and advertised services information, and they include a sequence number that is used to identify missing packets. For example, if 7 of 10 packets sent by the neighbor were received, then the probability for a successful packet transmission from this neighbor is 7/10 = 0.7 = 70%. Be aware that the *Quality* metric on the *Neighbor Status* display is calculated differently, so there may not be a perfect alignment when comparing the two quality metrics.
 
   - ``NLQ`` or Neighbor Link Quality is the neighbor node's view of the percent of :abbr:`OLSR (Optimized Link State Routing protocol)` packets received from your node. This measures the quality of the link from the neighbor's side.
 

--- a/arednGettingStarted/node_status.rst
+++ b/arednGettingStarted/node_status.rst
@@ -112,7 +112,9 @@ Distance
   .. note:: If no GPS coordinates were entered, then the distance cannot be calculated and that metric will not be considered in the LQM improvement process.
 
 Quality
-  The Link Quality expressed as a percent. This is calculated as the moving average of total sent packets over total sent packets plus retransmissions. For example, if the node had to send every packet twice for it to be successfully received, the link quality would be 50%. An additional penalty is subtracted from Link Quality if the neighbor node is unpingable, which is explained in the *Advanced Configuration* section under "Ping Penalty".
+  The Link Quality expressed as a percent. This is calculated as the moving average of (total sent packets) divided by (total sent packets plus retransmissions). For example, if the node had to send every packet twice for it to be successfully received, the link quality would be 50%. Be aware that the *LQ/NLQ* metrics on the *Mesh Status* display are calculated differently, so there may not be a perfect alignment when comparing the two quality metrics.
+
+  An additional penalty is subtracted from Link Quality if the neighbor node is unpingable, which is explained in the *Advanced Configuration* section under "Ping Penalty".
 
 Status
   The current status of each radio link. Valid status identifiers include:


### PR DESCRIPTION
Questions have been raised in the forum about the difference between the quality metrics on the Mesh Status vs. Neighbor Status pages.