### PR TITLE
include xlink identifier on Mesh and Neighbor Status

### DIFF
--- a/arednGettingStarted/mesh_status.rst
+++ b/arednGettingStarted/mesh_status.rst
@@ -41,6 +41,8 @@ Current Neighbors
 
   - ``(dtd)`` indicates a *Device to Device* connection (typically using an Ethernet cable) between the nodes.
 
+  - ``(xlink)`` indicates a connection between the nodes that traverses cross-linked devices.
+
   - ``(tun)`` indicates the path to the neighbor node is over an Internet tunnel. ``(tun*?)`` next to a mesh node in the *Remote Nodes* column indicates the node has tunnel links over the Internet to connect mesh islands together. ``?`` is a number indicating the number of tunnel connections on that node.
 
   - ``(wan)`` indicates the node has been configured as a *Mesh Gateway*. Typically this is a gateway to the Internet, but it may also be to another isolated network.

--- a/arednGettingStarted/node_status.rst
+++ b/arednGettingStarted/node_status.rst
@@ -101,7 +101,7 @@ Neighbor
   The remote neighbor node name with a clickable link to open that node's *Status* display.
 
 Link
-  The type of link your node has with each remote node. Valid link types are *RF* for a radio link, *DtD* for a direct device-to-device connection, and *Tunnel* for a tunnel link.
+  The type of link your node has with each remote node. Valid link types are ``RF`` for a radio link, ``DtD`` for a direct device-to-device connection, ``Xlink`` for a connection over cross-linked devices, and ``Tunnel`` for a tunnel link.
 
 SNR
   The Signal-to-Noise ratio in dB for both sides of any radio links (local SNR / remote SNR).


### PR DESCRIPTION
_Xlink_ is found in aredn PR #545.  This doc PR includes `xlink` as a possible identifier that might be noticed on the **Mesh Status** and **Neighbor Status** displays.  