### PR TITLE
reset doc title to latest nightly build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,9 +25,9 @@ copyright = f'{date.today().year}, Amateur Radio Emergency Data Network, Inc. Li
 author = u'Amateur Radio Emergency Data Network, Inc.'
 
 # The short X.Y version
-version = u'3.22.12.0'
+version = u'latest'
 # The full version, including alpha/beta/rc tags
-release = u'3.22.12.0'
+release = u'Latest Nightly Build'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
This PR can be merged immediately.  It resets the doc title for "latest" to "Latest Nightly Build" -- this will pick up all doc additions going forward beyond the 3.22.12.0 release.