### PR TITLE
Add Internationalization to AREDN

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Proposed Changes
+- change one
+- change two
+
+## Related Issue
+- include issue here
+
+## Additional Info
+- include helpful context or details
+
+## Checklist
+- [ ] Tests
+- [ ] Documentation
+
+## Screenshots
+
+Original            |  Updated
+:------------------------:|:------------------------:
+** original screenshot ** | ** updated screenshot **

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .DS_Store
+.vscode
 make.bat
 index.rst.original
 _build/
+
+# Remove when internationalization pull request is accepted; 
+# this is where .po/.mo files for translations would go during build
+locale 

--- a/Internationalization.md
+++ b/Internationalization.md
@@ -1,0 +1,21 @@
+# Internationalization and AREDN
+
+## Overview
+
+In an effort to make the AREDN network more globally accessible to non-English speaking communities, the AREDN documentation has integrated an `internationalization` framework. At a high level, this is a three-step process.
+
+1. Pull request to add necessary libraries and changes to `conf.py` to facilitate a multi-language environment of the documentation.
+2. Using Weblate or Transifex, establish an online capability (and associated change management/pull request process that feeds into the Github repository) that allows those proficient in a chosen foreign language to easily contribute their expertise in translating the AREDN documentation. 
+3. In an iterative process, seek ways to expand and improve the workflow as more languages are integrated.
+
+## Weblate or Transifex
+
+TODO - setup online translation hub for selected language(s)
+
+## References
+
+* [Localization of documentation](https://docs.readthedocs.io/en/stable/localization.html) in `Read the Docs`
+* [sphinx-intl](https://sphinx-intl.readthedocs.io/en/master/quickstart.html) - translation support utility for Sphinx
+* Integrating Internationalization with [Weblate](https://docs.weblate.org/en/latest/devel/starting.html) or [Transifex](https://developers.transifex.com/docs)
+* [Managing Translations in Sphinx](https://docs.readthedocs.io/en/stable/guides/manage-translations-sphinx.html)
+

--- a/conf.py
+++ b/conf.py
@@ -71,7 +71,12 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
+
+# Internationalization
+# Requires `sphinx-intl`, see https://sphinx-intl.readthedocs.io/en/master/quickstart.html
+locale_dirs = ['locale/']
+gettext_compact = False
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -109,7 +114,6 @@ html_theme = 'sphinx_rtd_theme'
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
-
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=4.4
 sphinx_rtd_theme>=1
+sphinx-intl>=2.1.0


### PR DESCRIPTION
## Proposed Changes
- `conf.py` - A couple lines added related to build process for `gettext` and `sphinx-intl`
- `requirements.txt` - added reference to `sphinx-intl`
- `.gitignore` - included build/dev folders to ignore, as well as ignoring `locale` folder for now until this PR is integrated
- `Internationalization.md` - first commit, docs to help with this PR and associated references
- `.github` folder with PR template to assist with future contributions to codebase

## Related Issue
#244 

## Additional Info
This is basically step one of a (likely) 3 step process to integrate other languages into the docs. Very much value the AREDN dev team's input on best way to proceed!

## Checklist
- [x] Tests - tested locally and was able to generate `.po` files in `locale` folder
- [x] Documentation - created `Internationalization.md` file to explain process and provide references