### PR TITLE
reset doc title to latest nightly build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,9 +25,9 @@ copyright = f'{date.today().year}, Amateur Radio Emergency Data Network, Inc. Li
 author = u'Amateur Radio Emergency Data Network, Inc.'
 
 # The short X.Y version
-version = u'3.23.4.0'
+version = u'latest'
 # The full version, including alpha/beta/rc tags
-release = u'3.23.4.0'
+release = u'Latest Nightly Build'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Since release 3.23.4.0 has been successfully tagged, we can reset the documentation title to latest nightly build now.