### PR TITLE
update sphinx version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,7 +33,7 @@ release = u'Latest Nightly Build'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '6.2'
+needs_sphinx = '5.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
It looks like sphinx version 5.3 is the latest supported on ReadTheDocs, so we'll have to settle for that.