### PR TITLE
Fix what the IP addresses are for with xlinks

### DIFF
--- a/arednHow-toGuides/xlinks.rst
+++ b/arednHow-toGuides/xlinks.rst
@@ -2,7 +2,7 @@
 Using Cross Links
 =================
 
-*Contributor: Tim Wilkerson KN6PLV*
+*Contributor: Tim Wilkinson KN6PLV*
 
 A cross-link allows you to pass AREDN |trade| traffic across non-AREDN |trade| network links.
 
@@ -24,13 +24,13 @@ You can use either a *Mikrotik hAP ac2* or *ac3* as the AREDN |trade| device on 
   :alt: Advanced Networking
   :align: center
 
-In this example we chose VLAN ``20`` because it is not in use anywhere else on our network. We assigned an *IP Address* of ``172.16.1.1`` for the PtP radio attached to this node, and we assigned ``172.16.1.2`` as the *Peer Address* for the PtP radio on the other side of the link. The *Weight* is set to ``1`` which is the same weight as would be used by a tunnel connection, but this can be increased if you want the cross-link to be chosen at a lower priority for routing traffic on the mesh. *Port* ``3`` was chosen because it is an open port on this device. After entering your values, click *Save Changes* to save the new cross-link information. Now you can cable your near-side PtP device to port 3 on your AREDN |trade| node.
+In this example we chose VLAN ``20`` because it is not in use anywhere else on our network. We assigned an *IP Address* of ``172.16.1.1`` for the this node, and we assigned ``172.16.1.2`` as the *Peer Address* for the node on the other side of the link. The xlink knows nothing about the details or configuration of the PtP radios, or their IP addresses. The *Weight* is set to ``1`` which is the same weight as would be used by a tunnel connection, but this can be increased if you want the cross-link to be chosen at a lower priority for routing traffic on the mesh. *Port* ``3`` was chosen because it is an open port on this device. After entering your values, click *Save Changes* to save the new cross-link information. Now you can cable your near-side PtP device to port 3 on your AREDN |trade| node.
 
 .. image:: _images/xlink.png
   :alt: Cross-link diagram
   :align: center
 
-Next, open the **Administration > Advanced Network** page on the node for the other side of the PtP link. Set the *IP Address* for the PtP radio attached to this node to ``172.16.1.2`` and the *Peer Address* for the PtP radio on the other side of the link to ``172.16.1.1``. The *Weight* is set to ``1`` which is the same weight as would be used by a tunnel connection, but this can be increased if you want the cross-link to be chosen at a lower priority for routing traffic on the mesh. In our example we are setting the *Port* to ``4`` because it is an open port on this device. After entering your values, click *Save Changes* to save the cross-link configuration for this side of the PtP link. Now you can cable your far-side PtP device to port 4 on your AREDN |trade| node.
+Next, open the **Administration > Advanced Network** page on the node for the other side of the PtP link. Set the *IP Address* for this node to ``172.16.1.2`` and the *Peer Address* for the node on the other side of the link to ``172.16.1.1``. The *Weight* is set to ``1`` which is the same weight as would be used by a tunnel connection, but this can be increased if you want the cross-link to be chosen at a lower priority for routing traffic on the mesh. In our example we are setting the *Port* to ``4`` because it is an open port on this device. After entering your values, click *Save Changes* to save the cross-link configuration for this side of the PtP link. Now you can cable your far-side PtP device to port 4 on your AREDN |trade| node.
 
 Configure the intermediate Point-to-Point link
 ----------------------------------------------


### PR DESCRIPTION
The IP addresses for xlinks are for the nodes and not for the radios in between.

Note that I can't fix the diagram :-(

https://github.com/aredn/documentation/issues/343