### PR TITLE
arednGettingStarted: ssh key comment req note

### DIFF
--- a/arednGettingStarted/advanced_config.rst
+++ b/arednGettingStarted/advanced_config.rst
@@ -403,6 +403,8 @@ Authorized SSH Keys
 
   .. note:: If you plan to use ssh keys you may want to review **Use PuTTYGen to Make SSH Keys** in the **How-To Guide** section which describes this process in detail for users of Microsoft Windows computers.
 
+  ssh keys are only valid if they contain a string in the form of ``<USER>@<SOMEWHERE>`` in the comment section of the key. ssh keys generated with the above tools add this comment by default.
+
 Support Data
   There may be times when you want to view more detailed information about the configuration and operation of your node, or even forward this information to the AREDN |trade| team in order to get help with a problem. Click the *Download Support Data* button to save a compressed archive file to your local computer.
 


### PR DESCRIPTION
## Description

Including a note in the documentation around the requirement that any ssh key add to an aredn node needs to have the comment field in
a specific format `USER@SOMEWHERE`. This came up recently in a conversation: https://github.com/aredn/aredn/issues/1113#issuecomment-1982149295
