### PR TITLE
remove broken links in beg guide

### DIFF
--- a/arednHow-toGuides/beginner-guide.rst
+++ b/arednHow-toGuides/beginner-guide.rst
@@ -14,13 +14,7 @@ RF access to the network
 
 How do you find out where the nearest network node is? There are several ways:
 
-- Check the mesh map at arednmesh.org. If you don’t find one near your QTH, don’t despair; the map only shows a fraction of the nodes on the air. If you’re in any of these areas, there are realtime network maps that can help you determine if there’s a node in your area.
-
-  - Central & Southern California: https://mapping.kg6wxc.net/meshmap
-  - Yakima, WA: http://ka7hak.thatip.net:7773/meshmap
-  - Oregon: https://arden.k9rcp.net/meshmap/map_display.php
-  - San Franciso Bay Area: https://sfmap.xojs.org/
-  - Hawaii: http://42561.noip.us:8888/meshmap
+- Check the worldwide map at `arednmesh.org <https://worldmap.arednmesh.org/>`_. 
 
 - Create an account on arednmesh.org and see if there’s a Regional Forum for your area. Ask there for local information. If you don’t find a regional forum for your area, get it started by asking the webmaster, Randy WU2S, to create one for you. Search for his callsign using the search function, and by finding it you’ll be able to drop him a note. Once it’s created, create a post mentioning you’d like to get started and asking if there’s any activity near you.
 


### PR DESCRIPTION
After the periodic link check on the documentation set, several broken links were identified in the beginner guide section. 