### PR TITLE
Update link to latest version of MeshChat

### DIFF
--- a/arednServicesGuide/chat_programs.rst
+++ b/arednServicesGuide/chat_programs.rst
@@ -21,9 +21,7 @@ Although MeshChat is a commonly deployed service, it is a third party package wh
 
 As originally designed, MeshChat uses the Perl programming language and is able to run either on an AREDN® node or on a LAN-connected Debian or Raspberry Pi computer. After the retirement of Perl on AREDN® nodes, there are now alternative MeshChat packages which use the Lua programming language for running on nodes. If you are running the original Perl version on an external computer, you can still use the new Lua API on your node to provide the computer with the list of MeshChat nodes. These packages are available at the following links:
 
-- `Latest Lua version of Meshchat at the new package maintainer's repository <https://github.com/hickey/meshchat/releases>`_
-
-- `Older Lua version of Meshchat (no longer maintained) <https://github.com/kn6plv/meshchat>`_
+- `Latest Lua version of MeshChat <https://github.com/kn6plv/meshchat>`_
 
 - Original Perl version for running Meshchat on a Raspbian or Debian computer (no longer maintained) 
 


### PR DESCRIPTION
The Hickey version of MeshChat is now out of date and no PR's have been accepted to fix it. So let's point at my version which will work with the latest release.